### PR TITLE
packaging images in deb

### DIFF
--- a/build.conf
+++ b/build.conf
@@ -5,8 +5,8 @@ uploaddir=/var/lib/tftp
 #builddir=../build
 #ramdisksize=3G
 
-board=bpi-r2
-#board=bpi-r64
+#board=bpi-r2
+board=bpi-r64
 #r64 uses 2 ethernet-chips (setting choose which dtb is used)
 #boardversion=1.0
 #mainline uboot for r64 needs 64bit uImage

--- a/build.sh
+++ b/build.sh
@@ -243,6 +243,15 @@ function pack {
 	cd $olddir
 }
 
+function pack_debs {
+	get_version
+	echo "pack linux-headers, linux-image, linux-libc-dev debs..."
+    echo "LOCALVERSION=${gitbranch} board=$board ARCH=$ARCH CROSS_COMPILE=$CROSS_COMPILE"
+	LOCALVERSION="${gitbranch}" board="$board" make bindeb-pkg
+	ls ../*.deb
+}
+
+
 function upload {
 	get_version
 	#if [[ "$board" == "bpi-r64" ]];then
@@ -817,6 +826,11 @@ if [ -n "$kernver" ]; then
 		"pack")
 			echo "Pack Kernel to Archive"
 			pack
+			;;
+
+		"pack_debs")
+			echo "Pack Kernel to linux-*.deb"
+			pack_debs
 			;;
 
 		"install")

--- a/scripts/package/builddeb
+++ b/scripts/package/builddeb
@@ -82,6 +82,19 @@ mkdir -m 755 -p "$tmpdir/DEBIAN"
 mkdir -p "$tmpdir/lib" "$tmpdir/boot"
 mkdir -p "$kernel_headers_dir/lib/modules/$version/"
 
+case $board in
+bpi-r64|bpi-r2)
+	mkdir -p "$tmpdir/boot/bananapi/$board/linux/dtb"
+	installed_image_path="boot/bananapi/$board/linux/uImage_nodt-$version"
+
+	cp ./$board.dtb "$tmpdir/boot/bananapi/$board/linux/dtb/$board-$version.dtb"
+	source_image_path="./uImage_nodt"
+	;;
+*)
+	source_image_path="$($MAKE -s -f $srctree/Makefile image_name)"
+	;;
+esac
+
 # Build and install the kernel
 if [ "$ARCH" = "um" ] ; then
 	mkdir -p "$tmpdir/usr/lib/uml/modules/$version" "$tmpdir/usr/bin" "$tmpdir/usr/share/doc/$packagename"
@@ -93,7 +106,7 @@ else
 	cp System.map "$tmpdir/boot/System.map-$version"
 	cp $KCONFIG_CONFIG "$tmpdir/boot/config-$version"
 fi
-cp "$($MAKE -s -f $srctree/Makefile image_name)" "$tmpdir/$installed_image_path"
+cp "$source_image_path" "$tmpdir/$installed_image_path"
 
 if is_enabled CONFIG_OF_EARLY_FLATTREE; then
 	# Only some architectures with OF support have this target


### PR DESCRIPTION
Build linux-headers, linux-image and linux-libc-dev deb packages for BPI-R2/R64.
How to use:
```
bash build.sh importconfig
bash build.sh build
bash build.sh cryptodev
bash build.sh pack
bash build.sh pack_debs
ls ../*.deb
../linux-headers-5.4.17-bpi-r64-main-packaged_5.4.17-bpi-r64-main-packaged-1_arm64.deb  ../linux-libc-dev_5.4.17-bpi-r64-main-packaged-1_arm64.deb
../linux-image-5.4.17-bpi-r64-main-packaged_5.4.17-bpi-r64-main-packaged-1_arm64.deb
...
```
Pros:
- deb is better than homeless files at /lib/modules
- linux headers, for building with DKMS external modules, e.g. wireguard

Now ./uImage_nodt is used as kernel binary after "build.sh build", but following step make "make bindeb-pkg" rebuilds the kernel, e.g. version changes. TODO: intergrate into builddeb 

```
mkimage -A ${uimagearch} -O linux -T kernel -C none -a 40080000 -e 40080000 ...
```