### PR TITLE
Backport fix max voltage (BPI R2)

### DIFF
--- a/drivers/cpufreq/mediatek-cpufreq.c
+++ b/drivers/cpufreq/mediatek-cpufreq.c
@@ -693,6 +693,15 @@ static const struct mtk_cpufreq_platform_data mt2701_platform_data = {
 	.ccifreq_supported = false,
 };
 
+static const struct mtk_cpufreq_platform_data mt7622_platform_data = {
+	.min_volt_shift = 100000,
+	.max_volt_shift = 200000,
+	.proc_max_volt = 1360000,
+	.sram_min_volt = 0,
+	.sram_max_volt = 1360000,
+	.ccifreq_supported = false,
+};
+
 static const struct mtk_cpufreq_platform_data mt8183_platform_data = {
 	.min_volt_shift = 100000,
 	.max_volt_shift = 200000,
@@ -724,8 +733,8 @@ static const struct mtk_cpufreq_platform_data mt8516_platform_data = {
 static const struct of_device_id mtk_cpufreq_machines[] __initconst = {
 	{ .compatible = "mediatek,mt2701", .data = &mt2701_platform_data },
 	{ .compatible = "mediatek,mt2712", .data = &mt2701_platform_data },
-	{ .compatible = "mediatek,mt7622", .data = &mt2701_platform_data },
-	{ .compatible = "mediatek,mt7623", .data = &mt2701_platform_data },
+	{ .compatible = "mediatek,mt7622", .data = &mt7622_platform_data },
+	{ .compatible = "mediatek,mt7623", .data = &mt7622_platform_data },
 	{ .compatible = "mediatek,mt8167", .data = &mt8516_platform_data },
 	{ .compatible = "mediatek,mt817x", .data = &mt2701_platform_data },
 	{ .compatible = "mediatek,mt8173", .data = &mt2701_platform_data },

--- a/drivers/cpufreq/mediatek-cpufreq.c
+++ b/drivers/cpufreq/mediatek-cpufreq.c
@@ -711,20 +711,29 @@ static const struct mtk_cpufreq_platform_data mt8186_platform_data = {
 	.ccifreq_supported = true,
 };
 
+static const struct mtk_cpufreq_platform_data mt8516_platform_data = {
+	.min_volt_shift = 100000,
+	.max_volt_shift = 200000,
+	.proc_max_volt = 1310000,
+	.sram_min_volt = 0,
+	.sram_max_volt = 1310000,
+	.ccifreq_supported = false,
+};
+
 /* List of machines supported by this driver */
 static const struct of_device_id mtk_cpufreq_machines[] __initconst = {
 	{ .compatible = "mediatek,mt2701", .data = &mt2701_platform_data },
 	{ .compatible = "mediatek,mt2712", .data = &mt2701_platform_data },
 	{ .compatible = "mediatek,mt7622", .data = &mt2701_platform_data },
 	{ .compatible = "mediatek,mt7623", .data = &mt2701_platform_data },
-	{ .compatible = "mediatek,mt8167", .data = &mt2701_platform_data },
+	{ .compatible = "mediatek,mt8167", .data = &mt8516_platform_data },
 	{ .compatible = "mediatek,mt817x", .data = &mt2701_platform_data },
 	{ .compatible = "mediatek,mt8173", .data = &mt2701_platform_data },
 	{ .compatible = "mediatek,mt8176", .data = &mt2701_platform_data },
 	{ .compatible = "mediatek,mt8183", .data = &mt8183_platform_data },
 	{ .compatible = "mediatek,mt8186", .data = &mt8186_platform_data },
 	{ .compatible = "mediatek,mt8365", .data = &mt2701_platform_data },
-	{ .compatible = "mediatek,mt8516", .data = &mt2701_platform_data },
+	{ .compatible = "mediatek,mt8516", .data = &mt8516_platform_data },
 	{ }
 };
 MODULE_DEVICE_TABLE(of, mtk_cpufreq_machines);

--- a/drivers/cpufreq/mediatek-cpufreq.c
+++ b/drivers/cpufreq/mediatek-cpufreq.c
@@ -373,13 +373,13 @@ static struct device *of_get_cci(struct device *cpu_dev)
 	struct platform_device *pdev;
 
 	np = of_parse_phandle(cpu_dev->of_node, "mediatek,cci", 0);
-	if (IS_ERR_OR_NULL(np))
-		return NULL;
+	if (!np)
+		return ERR_PTR(-ENODEV);
 
 	pdev = of_find_device_by_node(np);
 	of_node_put(np);
-	if (IS_ERR_OR_NULL(pdev))
-		return NULL;
+	if (!pdev)
+		return ERR_PTR(-ENODEV);
 
 	return &pdev->dev;
 }
@@ -401,7 +401,7 @@ static int mtk_cpu_dvfs_info_init(struct mtk_cpu_dvfs_info *info, int cpu)
 	info->ccifreq_bound = false;
 	if (info->soc_data->ccifreq_supported) {
 		info->cci_dev = of_get_cci(info->cpu_dev);
-		if (IS_ERR_OR_NULL(info->cci_dev)) {
+		if (IS_ERR(info->cci_dev)) {
 			ret = PTR_ERR(info->cci_dev);
 			dev_err(cpu_dev, "cpu%d: failed to get cci device\n", cpu);
 			return -ENODEV;


### PR DESCRIPTION
# Problème

On my side the kernel 6.1 crash with this following stacktrace:

```
[   17.002328] ------------[ cut here ]------------
[   17.006989] kernel BUG at drivers/regulator/core.c:424!
[   17.012235] Internal error: Oops - BUG: 0 [#1] SMP ARM
[   17.017391] Modules linked in: lima drm_shmem_helper gpu_sched spi_mt65xx pwm_mediatek sha1_arm sha256_arm sha512_arm aes_arm nf_conntrack_ftp ip6table_filter ip6_tables xt_state nf_conntrack nf_defrag_ipv6 nf_defrag_ipv4 fuse configfs ip_tables x_tables
[   17.040022] CPU: 1 PID: 20 Comm: kworker/1:0 Not tainted 6.1.22-bpi-r2-main #1
[   17.047266] Hardware name: Mediatek Cortex-A7 (Device Tree)
[   17.052853] Workqueue: events dbs_work_handler
[   17.057336] PC is at regulator_check_voltage+0xa8/0xec
[   17.062504] LR is at 0x118c30
[   17.065486] pc : [<c066bae0>]    lr : [<00118c30>]    psr: 200e0013
[   17.071763] sp : e087de00  ip : c19c4800  fp : c27d88b4
[   17.077007] r10: c1b15ec0  r9 : c2cb5a00  r8 : 00118c30
[   17.082268] r7 : c2606c00  r6 : 0013d620  r5 : 00000000  r4 : c2606c00
[   17.088818] r3 : c0670014  r2 : e087de18  r1 : e087de1c  r0 : c2606c00
[   17.095391] Flags: nzCv  IRQs on  FIQs on  Mode SVC_32  ISA ARM  Segment none
[   17.102610] Control: 10c5387d  Table: 886c806a  DAC: 00000051
[   17.108390] Register r0 information: slab kmalloc-1k start c2606c00 pointer offset 0 size 1024
[   17.117076] Register r1 information: 2-page vmalloc region starting at 0xe087c000 allocated at copy_process+0x1b8/0x10ec
[   17.128028] Register r2 information: 2-page vmalloc region starting at 0xe087c000 allocated at copy_process+0x1b8/0x10ec
[   17.138982] Register r3 information: non-slab/vmalloc memory
[   17.144689] Register r4 information: slab kmalloc-1k start c2606c00 pointer offset 0 size 1024
[   17.153355] Register r5 information: NULL pointer
[   17.158109] Register r6 information: non-paged memory
[   17.163206] Register r7 information: slab kmalloc-1k start c2606c00 pointer offset 0 size 1024
[   17.171873] Register r8 information: non-paged memory
[   17.176980] Register r9 information: slab kmalloc-64 start c2cb5a00 pointer offset 0 size 64
[   17.185487] Register r10 information: slab kmalloc-64 start c1b15ec0 pointer offset 0 size 64
[   17.194059] Register r11 information: slab kmalloc-192 start c27d8840 pointer offset 116 size 192
[   17.203003] Register r12 information: slab task_struct start c19c4800 pointer offset 0
[   17.210954] Process kworker/1:0 (pid: 20, stack limit = 0xb67caf0a)
[   17.217238] Stack: (0xe087de00 to 0xe087e000)
[   17.221628] de00: c2d0a980 00000000 0013d620 c2606c00 00118c30 c066e9b8 00118c30 0013d620
[   17.229881] de20: c2d0a980 00118c30 0013d620 0013d620 00118c30 c066ecd0 00124f80 c19c4800
[   17.238122] de40: 00000019 00000001 00000000 c654da05 c2d0ae00 c27d8880 00124f80 c0929e50
[   17.246336] de60: ded98050 c2c61800 3dfd2400 0013d620 4d7c6d00 c654da05 c1486140 c2c61800
[   17.254550] de80: 00000000 00000007 00000000 c14e703c 000fde80 0013d620 c1486140 c0922e6c
[   17.262767] dea0: dedb1470 c0cbe3e0 c129a370 ffffffff c2c61800 c2c61800 000fde80 0013d620
[   17.270980] dec0: 0000002c c654da05 dedb4305 c2c61800 c9469400 c9469580 c6099080 c9469400
[   17.279199] dee0: c9469580 dedb4305 c1473260 c09275b4 c946943c 00000000 c9469404 c2c61800
[   17.287397] df00: c144b604 c19c4800 dedb4305 c0928574 c946943c c1827c80 dedb10c0 dedb4300
[   17.295609] df20: 00000000 c0143dac c1827c98 c19c4800 dedb10c0 dedb10c0 dedb10dc c1827c80
[   17.303838] df40: dedb10c0 c1827c98 dedb10dc c1303d40 00000008 c19c4800 dedb10c0 c0144508
[   17.312050] df60: c19c4800 c14727b6 c1827c80 c19b7900 c19b7a80 e0825dec c19c4800 c01444ac
[   17.320247] df80: c1827c80 00000000 00000000 c014bd48 c19b7900 c014bc80 00000000 00000000
[   17.328443] dfa0: 00000000 00000000 00000000 c0100148 00000000 00000000 00000000 00000000
[   17.336637] dfc0: 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000
[   17.344831] dfe0: 00000000 00000000 00000000 00000000 00000013 00000000 00000000 00000000
[   17.353041]  regulator_check_voltage from regulator_set_voltage_unlocked+0xb4/0x124
[   17.360770]  regulator_set_voltage_unlocked from regulator_set_voltage+0x4c/0x8c
[   17.368204]  regulator_set_voltage from mtk_cpufreq_set_target+0xf8/0x394
[   17.375039]  mtk_cpufreq_set_target from __target_index+0x88/0x254
[   17.381254]  __target_index from od_dbs_update+0x150/0x17c
[   17.386771]  od_dbs_update from dbs_work_handler+0x34/0x60
[   17.392291]  dbs_work_handler from process_one_work+0x1c0/0x4a4
[   17.398247]  process_one_work from worker_thread+0x5c/0x50c
[   17.403850]  worker_thread from kthread+0xc8/0xcc
[   17.408582]  kthread from ret_from_fork+0x14/0x2c
[   17.413309] Exception stack(0xe087dfb0 to 0xe087dff8)
[   17.418378] dfa0:                                     00000000 00000000 00000000 00000000
[   17.426584] dfc0: 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000
[   17.434794] dfe0: 00000000 00000000 00000000 00000000 00000013 00000000
[   17.441430] Code: e1500005 a1a05000 aafffff4 eafffff1 (e7f001f2)
[   17.447548] ---[ end trace 0000000000000000 ]---
```

It's also a known issue here: https://bugzilla.kernel.org/show_bug.cgi?id=216690

# Solution

Backport the patch from the 6.3-rc kernel to the LTS kernel version to fix the issue.

I've tested on my BPI R2 and it fix the issue on my side.