### PR TITLE
Add ethernet Aliases to BananaPiR4

### DIFF
--- a/arch/arm64/boot/dts/mediatek/mt7988a-bananapi-bpi-r4-v0.dts
+++ b/arch/arm64/boot/dts/mediatek/mt7988a-bananapi-bpi-r4-v0.dts
@@ -22,6 +22,9 @@
 		led-failsafe = &led_green;
 		led-running = &led_green;
 		led-upgrade = &led_green;
+		ethernet0 = &gmac0;
+		ethernet1 = &gmac1;
+		ethernet2 = &gmac2;
 	};
 
 	chosen {

--- a/arch/arm64/boot/dts/mediatek/mt7988a-bananapi-bpi-r4.dts
+++ b/arch/arm64/boot/dts/mediatek/mt7988a-bananapi-bpi-r4.dts
@@ -20,6 +20,9 @@
 		led-failsafe = &led_green;
 		led-running = &led_green;
 		led-upgrade = &led_green;
+		ethernet0 = &gmac0;
+		ethernet1 = &gmac1;
+		ethernet2 = &gmac2;
 	};
 
 	chosen {


### PR DESCRIPTION
U-boot uses the ethernet aliases in the device-tree that is used by Linux to determine which nodes to modify to pass mac-address details configured in u-boot into Linux.

This fixup is performed in u-boot in [fdt_fixup_ethernet()](https://elixir.bootlin.com/u-boot/v2024.07/source/boot/fdt_support.c#L560)