### PR TITLE
Add overlay parameter to dtc command line for bpi-r4.

### DIFF
--- a/arch/arm64/boot/dts/mediatek/Makefile
+++ b/arch/arm64/boot/dts/mediatek/Makefile
@@ -132,3 +132,4 @@ dtb-$(CONFIG_ARCH_MEDIATEK) += mt8516-pumpkin.dtb
 # Device tree overlays support
 DTC_FLAGS_mt7986a-bananapi-bpi-r3 := -@
 DTC_FLAGS_mt7986a-bananapi-bpi-r3-mini := -@
+DTC_FLAGS_mt7988a-bananapi-bpi-r4 := -@


### PR DESCRIPTION
Add overlay parameter to dtc command line for bpi-r4. This allows proper use of the emmc/sd/wifi overlays.