### PR TITLE
Add "syscon" to pinctrl@1001f000 to fix the lan0-lan3 LEDs.

### DIFF
--- a/arch/arm64/boot/dts/mediatek/mt7988a.dtsi
+++ b/arch/arm64/boot/dts/mediatek/mt7988a.dtsi
@@ -297,7 +297,7 @@
 		};
 
 		pio: pinctrl@1001f000 {
-			compatible = "mediatek,mt7988-pinctrl";
+			compatible = "mediatek,mt7988-pinctrl", "syscon";
 			reg = <0 0x1001f000 0 0x1000>,
 			<0 0x11c10000 0 0x1000>,
 			<0 0x11d00000 0 0x1000>,


### PR DESCRIPTION
Without this the led show up under /sys/class/leds, but thye do not actually work.  With this the LEDs properly indicate link by default and can also be addressed using the /sys/class/leds references.