### PR TITLE
Fix SFP+ ports on latest kernel (BPI-R4 2x SFP+)

### DIFF
--- a/drivers/i2c/muxes/Kconfig
+++ b/drivers/i2c/muxes/Kconfig
@@ -67,6 +67,7 @@ config I2C_MUX_PCA9541
 config I2C_MUX_PCA954x
 	tristate "NXP PCA954x/PCA984x and Maxim MAX735x/MAX736x I2C Mux/switches"
 	depends on GPIOLIB || COMPILE_TEST
+	select RESET_GPIO
 	help
 	  If you say yes here you get support for NXP PCA954x/PCA984x
 	  and Maxim MAX735x/MAX736x I2C mux/switch devices.

--- a/drivers/net/phy/phylink.c
+++ b/drivers/net/phy/phylink.c
@@ -1150,6 +1150,7 @@ static enum inband_type phylink_get_inband_type(phy_interface_t interface)
 
 	case PHY_INTERFACE_MODE_1000BASEX:
 	case PHY_INTERFACE_MODE_2500BASEX:
+	case PHY_INTERFACE_MODE_10GBASER:
 		/* 1000base-X is designed for use media-side for Fibre
 		 * connections, and thus the Autoneg bit needs to be
 		 * taken into account. We also do this for 2500base-X


### PR DESCRIPTION
Some change in the logic of phylink.c in kernel version 6.17 caused the SFP+ Port to remain "MII", when it should be changed to "Direct Attach Copper" (this is what it used to do in the official old 5.4 kernel as well as 6.16, don't ask me why but the port does not work otherwise). This is caused by the following:

There are two code locations in which `phylink_get_inband_type` is called. If the return type is INBAND_NONE, some weird auto negotiation stuff happens which makes everything stop working. My commit adds `PHY_INTERFACE_MODE_10GBASER` to the switch case, such that INBAND_NONE is not returned. This fixes the connection on 6.17. There might need to be more things added to this enum, I don't know.

Next, in 6.18 (or as my bisect showed, a single commit after 6.17-rc1), the pca954x maintainers decided to remove legacy GPIO reset code. This causes the SFP+ transceiver to not even be powered on, leading to an idle timeout in the driver. My second commit simply reverts this.

With both of these fixes, I'm able to connect from my motherboard (ProArt X870E-Creator) via Cat.7 cable to this SFP+ transceiver: https://www.amazon.de/dp/B0D4YNDR6H
```
root@puppy-os /root $ dmesg | grep -i -e sfp2 -e sfplan0
[    0.230393] sfp sfp2: Host maximum power 3.0W
[    0.547851] sfp sfp2: module QSFPTEK          QT-SFP-10G-T     rev 03   sn QT6250512279     dc 250514  
[    1.506048] mtk_soc_eth 15100000.ethernet sfplan0: renamed from eth1
[   19.363545] mtk_soc_eth 15100000.ethernet sfplan0: configuring for inband/10gbase-r link mode
[   23.562307] mtk_soc_eth 15100000.ethernet sfplan0: Link is Up - 10Gbps/Full - flow control off
[   23.562497] br0: port 4(sfplan0) entered blocking state
[   23.562514] br0: port 4(sfplan0) entered forwarding state
root@puppy-os /root $ ethtool -m sfplan0
        Identifier                                : 0x03 (SFP)
        Extended identifier                       : 0x04 (GBIC/SFP defined by 2-wire interface ID)
        Connector                                 : 0x21 (Copper pigtail)
        Transceiver codes                         : 0x00 0x00 0x00 0x00 0x00 0x04 0x00 0x00 0x00
        Transceiver type                          : Passive Cable
        Encoding                                  : 0x00 (unspecified)
        BR Nominal                                : 10300MBd
        Rate identifier                           : 0x00 (unspecified)
        Length (SMF)                              : 0km
        Length (OM2)                              : 0m
        Length (OM1)                              : 0m
        Length (Copper or Active cable)           : 1m
        Length (OM3)                              : 0m
        Passive Cu cmplnce.                       : 0x00 (unspecified [SFF-8472 rev10.4 only])
        Vendor name                               : QSFPTEK
        Vendor OUI                                : 00:40:20
        Vendor PN                                 : QT-SFP-10G-T
        Vendor rev                                : 03
        Option values                             : 0x00 0x00
        BR margin max                             : 0%
        BR margin min                             : 0%
        Vendor SN                                 : QT6250512279
        Date code                                 : 250514
root@puppy-os /root $ ethtool sfplan0
Settings for sfplan0:
        Supported ports: [  ]
        Supported link modes:   2500baseX/Full
                                1000baseX/Full
                                10000baseCR/Full
        Supported pause frame use: Symmetric Receive-only
        Supports auto-negotiation: Yes
        Supported FEC modes: Not reported
        Advertised link modes:  10000baseCR/Full
        Advertised pause frame use: Symmetric Receive-only
        Advertised auto-negotiation: Yes
        Advertised FEC modes: Not reported
        Speed: 10000Mb/s
        Duplex: Full
        Auto-negotiation: on
        Port: Direct Attach Copper
        PHYAD: 0
        Transceiver: internal
        Current message level: 0x000000ff (255)
                               drv probe link timer ifdown ifup rx_err tx_err
        Link detected: yes
```