### PR TITLE
Fix LLVM-built kernels breaking due to immutable string write

### DIFF
--- a/drivers/net/ethernet/mediatek/mtk_eth_soc.c
+++ b/drivers/net/ethernet/mediatek/mtk_eth_soc.c
@@ -3720,7 +3720,7 @@ static int mtk_get_irqs_fe(struct platform_device *pdev, struct mtk_eth *eth)
 
 static int mtk_get_irqs_pdma(struct platform_device *pdev, struct mtk_eth *eth)
 {
-	char *rxring = "pdma0";
+	char rxring[] = "pdma0";
 	int i;
 
 	for (i = 0; i < MTK_PDMA_IRQ_NUM; i++) {


### PR DESCRIPTION
Closes #156 

LLVM-built kernels get rid of the write:
`rxring[4] = '0' + i;`
Which leads to all interrupts being incorrectly set.