### PR TITLE
Potential Vulnerability in Cloned Code

### DIFF
--- a/net/can/bcm.c
+++ b/net/can/bcm.c
@@ -864,6 +864,7 @@ static int bcm_delete_rx_op(struct list_head *ops, struct bcm_msg_head *mh,
 						  bcm_rx_handler, op);
 
 			list_del_rcu(&op->list);
+			synchronize_rcu();
 			bcm_remove_op(op);
 			return 1; /* done */
 		}


### PR DESCRIPTION
This PR fixes a potential security vulnerability in file `net/can/bcm.c` that was cloned from `https://github.com/torvalds/linux` but did not receive the security patch.

### Details:
Affected Files: 
- net/can/bcm.c

Original Fix: https://github.com/torvalds/linux/commit/d5f9023fa61ee8b94f37a93f08e94b136cf1e463

### What this PR does:
This PR applies the same security patch that was applied to the original repository to eliminate the potential vulnerability in the cloned code.

### References:
- https://nvd.nist.gov/vuln/detail/CVE-2021-3609
- https://github.com/torvalds/linux/commit/d5f9023fa61ee8b94f37a93f08e94b136cf1e463

Please review and merge this PR to ensure your repository is protected against this potential vulnerability.

