### PR TITLE
Reverted my previous patch and extended the fix to more than just mt7996

### DIFF
--- a/drivers/net/wireless/mediatek/mt76/mt7996/init.c
+++ b/drivers/net/wireless/mediatek/mt76/mt7996/init.c
@@ -34,6 +34,7 @@ static const struct ieee80211_iface_combination if_comb_global = {
 			       BIT(NL80211_CHAN_WIDTH_40) |
 			       BIT(NL80211_CHAN_WIDTH_80) |
 			       BIT(NL80211_CHAN_WIDTH_160),
+	.beacon_int_min_gcd = 100,
 };
 
 static const struct ieee80211_iface_combination if_comb_global_7992 = {
@@ -46,6 +47,7 @@ static const struct ieee80211_iface_combination if_comb_global_7992 = {
 			       BIT(NL80211_CHAN_WIDTH_40) |
 			       BIT(NL80211_CHAN_WIDTH_80) |
 			       BIT(NL80211_CHAN_WIDTH_160),
+	.beacon_int_min_gcd = 100,
 };
 
 static const struct ieee80211_iface_limit if_limits[] = {

--- a/net/wireless/core.c
+++ b/net/wireless/core.c
@@ -750,8 +750,15 @@ int wiphy_verify_iface_combinations(struct wiphy *wiphy,
 			 * and IBSS in the same interface, but it seems that
 			 * some drivers support that, possibly only with fixed
 			 * beacon intervals for IBSS.
+			 *
+			 * Skip this for the multi-radio global combination,
+			 * which holds the union of all radios' capabilities
+			 * rather than a concurrent set; the real constraint is
+			 * enforced on each per-radio combination, verified with
+			 * combined_radio == false.
 			 */
-			if (WARN_ON(types & BIT(NL80211_IFTYPE_ADHOC) &&
+			if (!combined_radio &&
+			    WARN_ON(types & BIT(NL80211_IFTYPE_ADHOC) &&
 				    c->beacon_int_min_gcd)) {
 				return -EINVAL;
 			}


### PR DESCRIPTION
Reverted my previous patch which applies to just mt7996 and provided a more generic fix. I think this could manifest on similar boards too. See below.

The IBSS-vs-beacon_int_min_gcd check was missed in wiphy_verify_iface_combinations. When a driver supports IBSS on one radio and advertises a beacon_int_min_gcd for its AP/STATION interfaces, it generates a combination that simultaneously includes both NL80211_IFTYPE_ADHOC and a non-zero beacon_int_min_gcd. These should not coexist on a single radio.

Fix: Skip the check for the combined-radio global combination, matching the nearby DFS and P2P_DEVICE checks in a similar fashion using the combined_radio flag.