### PR TITLE
wifi: mt76: mt7996: fix NULL sta dereference in mt7996_tx_prepare_skb()

### DIFF
--- a/drivers/net/wireless/mediatek/mt76/mt7996/mac.c
+++ b/drivers/net/wireless/mediatek/mt76/mt7996/mac.c
@@ -1025,8 +1025,8 @@ int mt7996_tx_prepare_skb(struct mt76_dev *mdev, void *txwi_ptr,
 	if (!wcid)
 		wcid = &dev->mt76.global_wcid;
 
-	if ((is_8023 || ieee80211_is_data_qos(hdr->frame_control)) && sta->mlo &&
-	    likely(tx_info->skb->protocol != cpu_to_be16(ETH_P_PAE))) {
+	if ((is_8023 || ieee80211_is_data_qos(hdr->frame_control)) && sta &&
+	    sta->mlo && likely(tx_info->skb->protocol != cpu_to_be16(ETH_P_PAE))) {
 		u8 tid = tx_info->skb->priority & IEEE80211_QOS_CTL_TID_MASK;
 
 		link_id = (tid % 2) ? msta->seclink_id : msta->deflink_id;

--- a/drivers/net/wireless/mediatek/mt76/mt7996/mac.c
+++ b/drivers/net/wireless/mediatek/mt76/mt7996/mac.c
@@ -1060,7 +1060,7 @@ int mt7996_tx_prepare_skb(struct mt76_dev *mdev, void *txwi_ptr,
 	 * compatible with 802.11 EAPOL frame, we do the translation by
 	 * software
 	 */
-	if (tx_info->skb->protocol == cpu_to_be16(ETH_P_PAE) && sta->mlo) {
+	if (tx_info->skb->protocol == cpu_to_be16(ETH_P_PAE) && sta && sta->mlo) {
 		struct ieee80211_hdr *hdr = (void *)tx_info->skb->data;
 		struct ieee80211_bss_conf *link_conf;
 		struct ieee80211_link_sta *link_sta;


### PR DESCRIPTION
The link_id selection introduced for MLO unconditionally dereferences
sta->mlo, but mt7996_tx_prepare_skb() is reachable with sta == NULL:
frames scheduled from a vif txq (group-addressed/multicast data in AP
mode) as well as frames on the global wcid carry no station pointer.
On such a frame the byte load of sta->mlo faults:

  Unable to handle kernel read from unreadable memory at virtual
  address 000000000000001b
  pc : mt7996_tx_prepare_skb+0x2a0/0x570 [mt7996e]
  lr : mt76_dma_tx_queue_skb+0x4d0/0x688 [mt76]
  Call trace:
   mt7996_tx_prepare_skb+0x2a0/0x570 [mt7996e] (P)
   mt76_dma_tx_queue_skb+0x4d0/0x688 [mt76]
   __mt76_tx_queue_skb+0x4c/0x100 [mt76]
   mt76_txq_schedule_pending_wcid+0x1a0/0x23c [mt76]
   mt76_txq_schedule_pending+0x1bc/0x220 [mt76]
   mt76_tx_worker+0x30/0xfc [mt76]
  Code: 52801181 0a030021 7102203f 54fff061 (39406f61)