### PR TITLE
DSA user ports check GSO limits the conduit doesn't have

### DIFF
--- a/net/dsa/user.c
+++ b/net/dsa/user.c
@@ -2805,6 +2805,15 @@ int dsa_user_create(struct dsa_port *port)
 	SET_NETDEV_DEVLINK_PORT(user_dev, &port->devlink_port);
 	user_dev->dev.of_node = port->dn;
 	user_dev->vlan_features = conduit->vlan_features;
+	/* A user port hands its transmit skbs straight to the conduit, so a
+	 * segmentation offload accepted here is performed by the conduit's
+	 * hardware.  Inherit its limits, or the stack evaluates the user port
+	 * against the defaults and only discovers the real ceiling one
+	 * dev_queue_xmit() later - after validate_xmit_skb() has already
+	 * linearized any fragment list, which for a coalesced superpacket is
+	 * an order-5 GFP_ATOMIC allocation.
+	 */
+	netif_inherit_tso_max(user_dev, conduit);
 
 	p = netdev_priv(user_dev);
 	user_dev->pcpu_stat_type = NETDEV_PCPU_STAT_TSTATS;


### PR DESCRIPTION
> `dsa_user_create()` copies the conduit's `vlan_features` onto the user port,
> so the port advertises the conduit's segmentation offloads — but it never
> copies `tso_max_size` or `tso_max_segs`. The user port keeps the
> `GSO_MAX_SIZE`/`GSO_MAX_SEGS` defaults, and `gso_features_check()` evaluates
> every skb against a ceiling the hardware that will actually segment it does
> not have.
>
> The real limits are only applied one `dev_queue_xmit()` later, after the
> tagger hands the skb to the conduit. By then `validate_xmit_skb()` has
> already run on the user port, and since a conduit without
> `NETIF_F_FRAGLIST` makes the user port lack it too, any coalesced
> superpacket carrying a fragment list has been collapsed by
> `__skb_linearize()` — an order-5 `GFP_ATOMIC` allocation taken purely
> because the limits were checked at the wrong stage. A bridge on top is
> affected the same way, since
> `netdev_compute_master_upper_features()` takes the minimum across lower
> devices and the user port contributes the default.
>
> Inherit both, via `netif_inherit_tso_max()` — which is what vlan, bonding,
> team and macvlan already do.
>
> Separate branch from the MediaTek work because it's `net/dsa/`, but it was
> found on the same hardware: MT7988A conduit behind an MxL862xx switch.