### PR TITLE
ethtool -K … lro off` doesn't stick once an ntuple LRO rule exists

### DIFF
--- a/drivers/net/ethernet/mediatek/mtk_eth_soc.c
+++ b/drivers/net/ethernet/mediatek/mtk_eth_soc.c
@@ -3570,17 +3570,6 @@ static void mtk_rss_uninit(struct mtk_eth *eth)
 static netdev_features_t mtk_fix_features(struct net_device *dev,
 					  netdev_features_t features)
 {
-	if (!(features & NETIF_F_LRO)) {
-		struct mtk_mac *mac = netdev_priv(dev);
-		int ip_cnt = mtk_hwlro_get_ip_cnt(mac);
-
-		if (ip_cnt) {
-			netdev_info(dev, "RX flow is programmed, LRO should keep on\n");
-
-			features |= NETIF_F_LRO;
-		}
-	}
-
 	if ((features & NETIF_F_IP_CSUM) &&
 	    non_mtk_uses_dsa(dev))
 		features &= ~NETIF_F_IP_CSUM;


### PR DESCRIPTION
> `mtk_fix_features()` forces `NETIF_F_LRO` back on whenever the netdev has an
> LRO destination address programmed, so a request to disable LRO is silently
> reverted. `ndo_fix_features()` is where a driver resolves dependencies
> between features, not a veto — the stack treats an unhonoured request as a
> driver bug.
>
> The caller that matters is `dev_disable_lro()`. The bridge and the routing
> path call it to guarantee receive aggregation is off, because a device that
> coalesces segments it is about to forward re-segments them wrongly. It
> clears the bit, calls `netdev_update_features()`, and warns if the feature
> survives — which is what happens here: enslave the port to a bridge with an
> LRO rule programmed, `netdev_WARN()` fires, and hardware LRO stays on for a
> forwarding path.
>
> Programmed destination addresses are inert while LRO is off and are
> re-applied by `mtk_hwlro_netdev_enable()` if it's turned back on, so nothing
> is lost by honouring the request. Drop the override.