### PR TITLE
32-bit GDM counters wrap silently on MT7988

### DIFF
--- a/drivers/net/ethernet/mediatek/mtk_eth_soc.c
+++ b/drivers/net/ethernet/mediatek/mtk_eth_soc.c
@@ -1342,6 +1342,30 @@ static void mtk_stats_update(struct mtk_eth *eth)
 	}
 }
 
+/* MTK_GDM1_AF and MTK_GDM2_AF describe a two-GDM frame engine and are the
+ * only trigger the driver has for draining the counters from the hot path.
+ * On NETSYS v3 that trigger does not fire, so drain them on a timer as well.
+ */
+static void mtk_stats_work(struct work_struct *work)
+{
+	struct delayed_work *del_work = to_delayed_work(work);
+	struct mtk_eth *eth = container_of(del_work, struct mtk_eth,
+					   stats_work);
+
+	if (test_bit(MTK_HW_INIT, &eth->state) &&
+	    !test_bit(MTK_RESETTING, &eth->state)) {
+		/* mtk_stats_update() is written for the NAPI path and takes
+		 * stats_lock with spin_trylock().  Keep the lock out of two
+		 * different contexts.
+		 */
+		local_bh_disable();
+		mtk_stats_update(eth);
+		local_bh_enable();
+	}
+
+	schedule_delayed_work(&eth->stats_work, MTK_STATS_DRAIN_TIMEOUT);
+}
+
 static void mtk_get_stats64(struct net_device *dev,
 			    struct rtnl_link_stats64 *storage)
 {
@@ -5078,6 +5102,7 @@ static int mtk_cleanup(struct mtk_eth *eth)
 	mtk_free_dev(eth);
 	cancel_work_sync(&eth->pending_work);
 	cancel_delayed_work_sync(&eth->reset.monitor_work);
+	cancel_delayed_work_sync(&eth->stats_work);
 
 	return 0;
 }
@@ -6134,6 +6159,7 @@ static int mtk_probe(struct platform_device *pdev)
 	INIT_WORK(&eth->rx_dim.work, mtk_dim_rx);
 	atomic_set(&eth->reset.force, 0);
 	INIT_DELAYED_WORK(&eth->reset.monitor_work, mtk_hw_reset_monitor_work);
+	INIT_DELAYED_WORK(&eth->stats_work, mtk_stats_work);
 
 	eth->tx_dim.mode = DIM_CQ_PERIOD_MODE_START_FROM_EQE;
 	INIT_WORK(&eth->tx_dim.work, mtk_dim_tx);
@@ -6465,6 +6491,7 @@ static int mtk_probe(struct platform_device *pdev)
 	platform_set_drvdata(pdev, eth);
 	schedule_delayed_work(&eth->reset.monitor_work,
 			      MTK_DMA_MONITOR_TIMEOUT);
+	schedule_delayed_work(&eth->stats_work, MTK_STATS_DRAIN_TIMEOUT);
 
 	return 0;
 

--- a/drivers/net/ethernet/mediatek/mtk_eth_soc.h
+++ b/drivers/net/ethernet/mediatek/mtk_eth_soc.h
@@ -1478,6 +1478,12 @@ struct mtk_soc_data {
 
 #define MTK_DMA_MONITOR_TIMEOUT		msecs_to_jiffies(1000)
 
+/* The GDM MIB counters are clear-on-read and the packet counters are only
+ * 32 bits wide, so they have to be drained on a schedule rather than only
+ * when something asks for statistics.
+ */
+#define MTK_STATS_DRAIN_TIMEOUT		msecs_to_jiffies(1000)
+
 /* currently no SoC has more than 3 macs */
 #define MTK_MAX_DEVS	3
 
@@ -1569,6 +1575,9 @@ struct mtk_eth {
 	unsigned long			state;
 
 	const struct mtk_soc_data	*soc;
+
+	/* periodic drain of the clear-on-read GDM MIB counters */
+	struct delayed_work		stats_work;
 
 	spinlock_t			dim_lock;
 


### PR DESCRIPTION
> The GDMA MIB counters are clear-on-read, so a count never read is a count
> lost. The hardware raises an almost-full condition to ask for a drain, and
> `mtk_handle_status_irq()` tests for it — but `MTK_GDM1_AF`/`MTK_GDM2_AF` are
> `BIT(28)`/`BIT(29)`, unconditional definitions describing a two-GDM frame
> engine from the MT7621/MT7623 layout. MT7988 has three GDMs and there is no
> `MTK_GDM3_AF`.
>
> Measured on MT7988 with sticky per-bit accumulators on both frontend status
> registers, across idle and saturated 1G and 10G: bits 28 and 29 of
> `MTK_FE_INT_STATUS` are never set. Bits 23–25 are permanently asserted.
> `mtk_stats_update()` is never reached from the IRQ path on this SoC.
>
> That leaves `mtk_get_stats64()` and the ethtool op, which drain only when
> userspace asks. With nothing asking, the 32-bit packet, error and drop
> counters roll over silently — 2³² packets is under five minutes of 10G
> minimum-size traffic. Byte counters are a 64-bit pair and unaffected.
>
> The correct v3 bit assignment isn't in any public source and three
> permanently-asserted bits are not evidence of almost-full, so I'm not
> guessing at a new mask. This adds a delayed work that drains once a second
> regardless, shaped like `reset.monitor_work` — three orders of magnitude
> inside the wrap interval, ~40 register reads per second. The AF test stays;
> it's free and will start working if the right bits are ever established.
>
> Note for anyone testing: nothing may read `/proc/mtketh/dbg_regs` during a
> comparison run — the two paths steal clear-on-read counts from each other.