### PR TITLE
Fix a use-after-free in the QDMA TX path that silently corrupts forwarded traffic

### DIFF
--- a/drivers/net/ethernet/mediatek/mtk_eth_soc.c
+++ b/drivers/net/ethernet/mediatek/mtk_eth_soc.c
@@ -2617,10 +2617,9 @@ static int mtk_poll_tx_qdma(struct mtk_eth *eth, int budget,
 	while ((cpu != dma) && budget) {
 		u32 next_cpu = desc->txd2;
 
+		desc = mtk_qdma_phys_to_virt(ring, desc->txd2);
 		if ((desc->txd3 & TX_DMA_OWNER_CPU) == 0)
 			break;
-
-		desc = mtk_qdma_phys_to_virt(ring, desc->txd2);
 
 		tx_buf = mtk_desc_to_tx_buf(ring, desc,
 					    eth->soc->tx.desc_size);

--- a/drivers/net/ethernet/mediatek/mtk_eth_soc.c
+++ b/drivers/net/ethernet/mediatek/mtk_eth_soc.c
@@ -1845,9 +1845,29 @@ static int mtk_tx_map(struct sk_buff *skb, struct net_device *dev,
 		}
 	}
 
-	/* store skb to cleanup */
-	itx_buf->type = MTK_TYPE_SKB;
-	itx_buf->data = skb;
+	/* Attach the skb to the job's last descriptor, not its first.
+	 *
+	 * The QDMA releases descriptors progressively: a descriptor's DDONE
+	 * bit asserts that the engine has consumed that descriptor's buffer,
+	 * not that the job it belongs to has finished.  mtk_poll_tx_qdma()
+	 * reclaims in submission order, so with the skb on the first
+	 * descriptor it is freed - dropping every fragment page reference of
+	 * the whole job - as soon as the engine is done with the first
+	 * buffer, while the remaining buffers may still be queued for fetch.
+	 * Anything that then reuses or sanitises those pages (init_on_free
+	 * zeroes them immediately) is read by the engine instead of the
+	 * payload.  Keying the free to the last descriptor holds the pages
+	 * until every buffer has been consumed.
+	 */
+	if (MTK_HAS_CAPS(soc->caps, MTK_QDMA)) {
+		itx_buf->data = (void *)MTK_DMA_DUMMY_DESC;
+		tx_buf = mtk_desc_to_tx_buf(ring, txd, soc->tx.desc_size);
+		tx_buf->type = MTK_TYPE_SKB;
+		tx_buf->data = skb;
+	} else {
+		itx_buf->type = MTK_TYPE_SKB;
+		itx_buf->data = skb;
+	}
 
 	if (!MTK_HAS_CAPS(soc->caps, MTK_QDMA)) {
 		if (k & 0x1)

--- a/drivers/net/ethernet/mediatek/mtk_eth_soc.c
+++ b/drivers/net/ethernet/mediatek/mtk_eth_soc.c
@@ -1759,8 +1759,11 @@ static int mtk_tx_map(struct sk_buff *skb, struct net_device *dev,
 	int queue = skb_get_queue_mapping(skb);
 	int k = 0;
 
-	if (skb->len <= MTK_MIN_TX_LENGTH) {
-		if (skb_put_padto(skb, MTK_MIN_TX_LENGTH))
+	if (skb->len < MTK_MIN_TX_LENGTH) {
+		/* __skb_put_padto() must not free the skb here: the caller
+		 * frees it on every error return from this function.
+		 */
+		if (__skb_put_padto(skb, MTK_MIN_TX_LENGTH, false))
 			return -ENOMEM;
 
 		txd_info.last = !skb_is_nonlinear(skb);


### PR DESCRIPTION
> This is the fix for the zero-payload corruption I've been chasing: hardware
> TCP segmentation on MT7988A emitting segments whose payload is correct up to
> a point and zero from there to the segment boundary, ~36 ppm of transferred
> bytes, **with valid TCP checksums**. It is not a hardware defect.
>
> `mtk_tx_map()` stores the skb on the *first* descriptor of a job.
> `mtk_poll_tx_qdma()` reclaims in submission order and frees the skb when it
> reaches the descriptor carrying it. But QDMA release is per descriptor —
> `drx_ptr` advances and DDONE is written back as each buffer is consumed — so
> reclaiming the first descriptor only says the engine finished the *first
> buffer*. For a multi-descriptor job, and above all an LSO job whose
> fragments are fetched across the emission of up to 18 segments, that drops
> every fragment page reference while the engine still has buffers to read.
