### PR TITLE
Cut the AS21011 WAN link outage from 8.7 s to ~0.5 s on an interface bounce

### DIFF
--- a/drivers/net/phy/as21xx_1.9.2/as21xxx.c
+++ b/drivers/net/phy/as21xx_1.9.2/as21xxx.c
@@ -1615,6 +1615,21 @@ static int aeon_gen1_config_init(struct phy_device *phydev)
 		if (ret)
 			return ret;
 
+		/* The restarted MCU begins a fresh command sequence
+		 * while priv->parity_status still holds whatever the
+		 * commands before the reload left it at, so the first
+		 * command after the reload can match the parity of a
+		 * status the new firmware has not produced.
+		 * aeon_gen1_probe() re-syncs after loading the firmware
+		 * for this reason; do the same here. A failure is not
+		 * fatal - the retry loop below recovers, just noisily.
+		 */
+		ret = aeon_ipc_sync_parity(phydev, phydev->priv);
+		if (ret)
+			phydev_warn(phydev,
+				    "IPC parity sync after firmware reload failed (%d)\n",
+				    ret);
+
 		ret = aeon_wait_reset_complete(phydev);
 		if (!ret) {
 			/* Enable PTP clk if not already Enabled */

--- a/drivers/net/phy/as21xx_1.9.2/as21xxx.c
+++ b/drivers/net/phy/as21xx_1.9.2/as21xxx.c
@@ -743,7 +743,7 @@ static int aeon_ipc_send_cmd(struct phy_device *phydev,
 {
 	bool curr_parity;
 	int ret;
-	unsigned int val;
+	int val;
 
 	/* The IPC sync by using a single parity bit.
 	 * Each CMD have alternately this bit set or clear
@@ -780,8 +780,11 @@ static int aeon_ipc_send_cmd(struct phy_device *phydev,
 				phydev, MDIO_MMD_VEND1, VEND1_IPC_STS);
 	if (val < 0)
 		ret = val;
-	if (ret)
-		phydev_err(phydev, "%s fail to polling status failed: %d\n", __func__, ret);
+	if (ret) {
+		phydev_err(phydev, "%s: status poll failed: %d\n",
+			   __func__, ret);
+		return ret;
+	}
 	*ret_sts = val;
 	if ((val & AEON_IPC_STS_STATUS) != AEON_IPC_STS_STATUS_SUCCESS)
 		return -EINVAL;

--- a/drivers/net/phy/as21xx_1.9.2/as21xxx.c
+++ b/drivers/net/phy/as21xx_1.9.2/as21xxx.c
@@ -1514,6 +1514,26 @@ static void aeon_gen1_remove(struct phy_device *phydev)
 	#endif
 }
 
+/* Read the IPC mailbox status, rejecting a not-responding mailbox.
+ *
+ * An all-ones IPC_STS is not a status the MCU can produce: the SIZE
+ * field would encode 31 bytes, more than the eight data registers can
+ * carry (AEON_IPC_DATA_MAX), and 0x3f is not a valid response opcode.
+ * It is what a C45 read returns when nothing drives the data phase -
+ * the IPC MCU held in reset, or the firmware not loaded.
+ */
+static int aeon_ipc_read_sts(struct phy_device *phydev)
+{
+	int sts = phy_read_mmd(phydev, MDIO_MMD_VEND1, VEND1_IPC_STS);
+
+	if (sts < 0)
+		return sts;
+	if (sts == 0xffff)
+		return -ENODEV;
+
+	return sts;
+}
+
 static int aeon_wait_reset_complete(struct phy_device *phydev)
 {
 	int val;
@@ -1524,7 +1544,70 @@ static int aeon_wait_reset_complete(struct phy_device *phydev)
 
 static int aeon_gen1_config_init(struct phy_device *phydev)
 {
-	int ret = aeon_wait_reset_complete(phydev);
+	int sts = aeon_ipc_read_sts(phydev);
+	int ret = sts;
+
+	/* phy_detach() asserts the PHY reset line when the DT node has
+	 * reset-gpios, so every interface down/up cycle stops the IPC
+	 * MCU and loses the firmware. Probing the IPC in that state
+	 * cannot succeed, but it is not free: the completion poll in
+	 * aeon_ipc_send_cmd() runs its full 2 s budget against a static
+	 * IPC_STS, and the parity resync below then spends another 2 s
+	 * the same way, both ahead of the firmware reload that is the
+	 * only possible recovery. Read the mailbox first and go
+	 * straight to the reload when it does not answer.
+	 */
+	if (sts >= 0)
+		ret = aeon_wait_reset_complete(phydev);
+
+	if (ret && sts >= 0) {
+		struct as21xxx_priv *priv = phydev->priv;
+		int id1, id2;
+
+		/* An IPC failure while the firmware is still running is
+		 * a lost completion that left the driver-side parity bit
+		 * out of sync with the IPC MCU, not a HW reset: after
+		 * one missed completion every subsequent command matches
+		 * the stale IPC_STS of the previous exchange and fails
+		 * instantly.
+		 *
+		 * The mailbox answered, so attempt a cheap recovery
+		 * before the multi-second firmware reload. Instead of
+		 * the NOOP-based sync, whose completion poll can itself
+		 * match stale status, derive the next parity directly
+		 * from IPC_STS: it carries the parity of the last
+		 * command the MCU has seen, so a command with the
+		 * flipped bit is guaranteed to be taken as new and its
+		 * completion cannot be confused with a stale one. If
+		 * the MCU is wedged rather than desynced the retry
+		 * costs one poll timeout before reaching the
+		 * reload as before.
+		 *
+		 * The PHY IDs are logged for diagnosis only: PMA/PMD
+		 * PHYSID keeps the generic pre-firmware value even with
+		 * firmware running, and the post-firmware behavior of
+		 * the PCS copy on this silicon is not yet confirmed,
+		 * so neither is trusted as a firmware-alive gate.
+		 */
+		id1 = phy_read_mmd(phydev, MDIO_MMD_PCS, MII_PHYSID1);
+		id2 = phy_read_mmd(phydev, MDIO_MMD_PCS, MII_PHYSID2);
+		sts = aeon_ipc_read_sts(phydev);
+
+		phydev_warn(phydev,
+			    "IPC probe failed (%d), pcs id %04x:%04x ipc_sts %04x, attempting parity resync\n",
+			    ret, id1, id2, sts);
+
+		if (sts >= 0) {
+			mutex_lock(&priv->ipc_lock);
+			priv->parity_status =
+				!FIELD_GET(AEON_IPC_STS_PARITY, sts);
+			mutex_unlock(&priv->ipc_lock);
+
+			ret = aeon_ipc_get_fw_version(phydev);
+			phydev_warn(phydev, "parity resync %s (%d)\n",
+				    ret ? "failed" : "recovered", ret);
+		}
+	}
 
 	if (ret) {
 		aeon_cl45_write(phydev, MDIO_MMD_VEND1, VEND1_PTP_CLK, 0x48);


### PR DESCRIPTION
> Bouncing the WAN interface on the R4 Pro cost 8.7 s of link outage. Three
> causes.
>
> **A signedness bug.** `aeon_ipc_send_cmd()` polls into an `unsigned int`, so
> both `val < 0` tests are dead code. An MDIO error during the poll becomes a
> large positive value, `FIELD_GET()` extracts garbage, and the poll spins to
> `-ETIMEDOUT`. The poll error is then not returned at all: the code falls
> through and reports `-EINVAL` from a stale status — so one failure logs two
> different errnos, and if the leftover status happens to read SUCCESS it
> returns success with stale data.
>
> **Parity desync answered with a 4.5 s firmware reload.** The driver toggles
> its parity bit before knowing whether the MCU consumed the command, so a
> single lost completion leaves the two sides disagreeing, and every
> subsequent poll is satisfied instantly by the previous exchange's stale
> `IPC_STS`. `config_init` treated any such failure as "firmware is gone" and
> reloaded it over MDIO.
>
> The discriminator that works is `VEND1_IPC_STS` reading all-ones: not a
> status the MCU can produce (`STS_SIZE` would encode 31 bytes against a
> 16-byte maximum, and `0x3f` is not a valid opcode), it's what a C45 read
> returns when nothing drives the data phase. Mailbox dead → go straight to
> the reload, skipping two 2 s poll timeouts. Mailbox alive → derive the next
> parity from `IPC_STS`, which carries the parity of the last command the MCU
> actually saw, and retry once; recovery in tens of milliseconds.
>
> **No resync after a reload.** `probe` calls `aeon_ipc_sync_parity()` after
> loading firmware; the `config_init` reload path didn't, leaving
> `priv->parity_status` wherever the failed pre-reload commands put it. Two
> more failed commands and ~0.5 s. Patch 3 makes the reload path match probe.
