### PR TITLE
Park masked U3 ports instead of leaving them half-enabled

### DIFF
--- a/drivers/usb/host/xhci-mtk.c
+++ b/drivers/usb/host/xhci-mtk.c
@@ -219,6 +219,19 @@ static int xhci_mtk_host_enable(struct xhci_hcd_mtk *mtk)
 	/* power on and enable u3 ports except skipped ones */
 	for (i = 0; i < mtk->num_u3_ports; i++) {
 		if ((0x1 << i) & mtk->u3p_dis_msk) {
+			/*
+			 * Park skipped ports instead of leaving them in
+			 * their power-on default state: the port's PHY may
+			 * be uninitialized or its SerDes lane owned by
+			 * another controller (e.g. PCIe), in which case a
+			 * powered-up port whose MAC clock domain is never
+			 * released from reset can hold the interrupt line
+			 * asserted, getting it disabled by the spurious
+			 * IRQ detector and killing the whole host.
+			 */
+			value = readl(&ippc->u3_ctrl_p[i]);
+			value |= CTRL_U3_PORT_PDN | CTRL_U3_PORT_DIS;
+			writel(value, &ippc->u3_ctrl_p[i]);
 			u3_ports_disabled++;
 			continue;
 		}


### PR DESCRIPTION
> `xhci_mtk_host_enable()` skips ports listed in `mediatek,u3p-dis-msk`
> entirely — it neither powers them up nor down, so they keep the bootloader
> default, which on MediaTek IPPC is powered up and host-selected. But the
> mask exists precisely for ports whose U3 PHY is unusable: on the R4 Pro,
> ssusb0's U3 lane is muxed to PCIe2, so the DT masks U3 port 0 and omits the
> PHY.
>
> The port is therefore powered and host-selected with no initialized PHY and
> a MAC clock domain never released from reset, holding the controller's level
> interrupt asserted with a status `xhci_irq()` cannot acknowledge. The
> spurious-IRQ detector disables the line, and the perfectly good USB2 bus on
> the same controller dies with it — completions never arrive, the first
> `hub_event` needing a command parks in D state holding the hub lock, and
> `device_shutdown()` blocks behind it, hanging reboot.
>
> Explicitly set `CTRL_U3_PORT_PDN` and `CTRL_U3_PORT_DIS` for masked ports,
> mirroring what `host_enable()` does in reverse for active ones.
>
> Companion to the `clk-mt7988` fix (PR 1) — same board, same symptom class,
> independent causes. Both are needed.