### PR TITLE
Stop ~100 lines of `CMD 1802 returned error -19` on every R4 Pro boot

### DIFF
--- a/drivers/net/dsa/mxl862xx/mxl862xx-host.h
+++ b/drivers/net/dsa/mxl862xx/mxl862xx-host.h
@@ -12,6 +12,8 @@ int mxl862xx_api_wrap(struct mxl862xx_priv *priv, u16 cmd, void *data, u16 size,
 
 #define MXL862XX_API_WRITE(dev, cmd, data) \
 	mxl862xx_api_wrap(dev, cmd, &(data), sizeof((data)), false, false)
+#define MXL862XX_API_WRITE_QUIET(dev, cmd, data) \
+	mxl862xx_api_wrap(dev, cmd, &(data), sizeof((data)), false, true)
 #define MXL862XX_API_READ(dev, cmd, data) \
 	mxl862xx_api_wrap(dev, cmd, &(data), sizeof((data)), true, false)
 #define MXL862XX_API_READ_QUIET(dev, cmd, data) \

--- a/drivers/net/dsa/mxl862xx/mxl862xx.c
+++ b/drivers/net/dsa/mxl862xx/mxl862xx.c
@@ -248,7 +248,7 @@ static int mxl862xx_phy_read_mmd(struct mxl862xx_priv *priv, int addr,
 	};
 	int ret;
 
-	ret = MXL862XX_API_READ(priv, INT_GPHY_READ, param);
+	ret = MXL862XX_API_READ_QUIET(priv, INT_GPHY_READ, param);
 	if (ret)
 		return ret;
 
@@ -265,7 +265,7 @@ static int mxl862xx_phy_write_mmd(struct mxl862xx_priv *priv, int addr,
 		.data = cpu_to_le16(data),
 	};
 
-	return MXL862XX_API_WRITE(priv, INT_GPHY_WRITE, param);
+	return MXL862XX_API_WRITE_QUIET(priv, INT_GPHY_WRITE, param);
 }
 
 static int mxl862xx_phy_read_mii_bus(struct mii_bus *bus, int addr, int regnum)


### PR DESCRIPTION
> The four internal 2.5G PHYs on the MxL86252C are GPY cores reachable only
> through the switch firmware's MDIO relay. `mxl-gpy` writes optional VEND1
> vendor registers during `config_init` (LED config, temperature/WOL mailbox)
> and tolerates failures. The R4 Pro's 1.0.70 firmware doesn't implement them
> and rejects each write with `-ENODEV`, and the relay logs every one:
>
> ```
> mxl862xx mdio-bus:10: CMD 1802 returned error -19
> ```
>
> ~100 lines per cold boot on a board where all four ports come up and pass
> traffic normally. These are PHY-layer accesses whose success is the PHY
> driver's business, not the switch's, so route both relay directions through
> the existing quiet path (already used for the firmware-version probe).
> Genuine switch-command failures are still logged.