### PR TITLE
Fix USB IRQ storm on R4 Pro when the CN15 M.2 slot is empty

### DIFF
--- a/drivers/clk/mediatek/clk-mt7988-infracfg.c
+++ b/drivers/clk/mediatek/clk-mt7988-infracfg.c
@@ -229,7 +229,17 @@ static const struct mtk_gate infra_clks[] = {
 			  CLK_IS_CRITICAL),
 	GATE_INFRA3_FLAGS(CLK_INFRA_USB_FRMCNT_CK_P1, "infra_usb_frmcnt_ck_p1", "usb_frmcnt_p1_sel",
 			  9, CLK_IS_CRITICAL),
-	GATE_INFRA3(CLK_INFRA_USB_PIPE, "infra_usb_pipe", "sspxtp_sel", 10),
+	/*
+	 * Reference clock of the U3/PCIe combo serdes (xphyu3port0). The lane
+	 * is shared between ssusb0 and pcie2, but only the PHY consumer that
+	 * claims it holds this gate. On boards where pcie2 owns the lane, a
+	 * failed pcie2 probe (e.g. empty M.2 slot) calls phy_exit() and gates
+	 * this clock while ssusb0 still has a live SuperSpeed root hub on the
+	 * same PHY, which wedges the shared SSUSB interrupt. CCF cannot model
+	 * the cross-IP sharing, so keep the gate on.
+	 */
+	GATE_INFRA3_FLAGS(CLK_INFRA_USB_PIPE, "infra_usb_pipe", "sspxtp_sel", 10,
+			  CLK_IS_CRITICAL),
 	GATE_INFRA3(CLK_INFRA_USB_PIPE_CK_P1, "infra_usb_pipe_ck_p1", "usb_phy_sel", 11),
 	GATE_INFRA3(CLK_INFRA_USB_UTMI, "infra_usb_utmi", "top_xtal", 12),
 	GATE_INFRA3(CLK_INFRA_USB_UTMI_CK_P1, "infra_usb_utmi_ck_p1", "top_xtal", 13),


### PR DESCRIPTION
> On the BPI-R4 Pro, ssusb0's SuperSpeed lane and pcie2 share one serdes.
> pcie2 is the only consumer holding `CLK_INFRA_USB_PIPE`, so when the M.2 slot
> is empty and pcie2 fails link training, its error path gates the clock out
> from under a SuperSpeed root hub that is still registered and polling.
> The result is an unacknowledgeable interrupt, `nobody cared`, a disabled
> IRQ line, and then a hang in `xhci_disable_slot()` at the next USB teardown
> or reboot.
>
> Marking the gate `CLK_IS_CRITICAL` keeps the lane's reference clock alive.
> Only port 0 is affected; ssusb1 uses a separate gate.
>
> Tested on BPI-R4 Pro 8X with CN15 empty. Also see the companion
> `xhci-mtk` fix (PR 5), which addresses the other half of the same symptom.