### PR TITLE
FIT configs to boot the R4 Pro 8X with the M.2 slots live

### DIFF
--- a/bpi-r4.its
+++ b/bpi-r4.its
@@ -185,6 +185,18 @@
 			data = /incbin/("./arch/arm64/boot/dts/mediatek/mt7988a-bananapi-bpi-r4-pro-8x-wan-sfp.dtbo");
 			type = "flat_dt";
 		};
+		fdt-r4pro-8x-emmc {
+			description = "BPI-R4 Pro 8X eMMC (base+cn13+cn14+emmc)";
+			data = /incbin/("./arch/arm64/boot/dts/mediatek/mt7988a-bananapi-bpi-r4-pro-8x-emmc.dtb");
+			type = "flat_dt"; arch = "arm64"; load = <0x47000000>; compression = "none";
+			hash-1 { algo = "sha1"; };
+		};
+		fdt-r4pro-8x-sd {
+			description = "BPI-R4 Pro 8X SD (base+cn13+cn14+sd)";
+			data = /incbin/("./arch/arm64/boot/dts/mediatek/mt7988a-bananapi-bpi-r4-pro-8x-sd.dtb");
+			type = "flat_dt"; arch = "arm64"; load = <0x47000000>; compression = "none";
+			hash-1 { algo = "sha1"; };
+		};
 /*		ramdisk-1 {
 			description = "ramdisk";
 			data = /incbin/("./rootfs_arm64.cpio.gz");
@@ -199,6 +211,18 @@
 	};
 	configurations {
 		default = "conf-sd";
+		conf-r4pro-8x-emmc {
+			description = "Boot BPI-R4 Pro 8X (eMMC)";
+			kernel = "kernel-1";
+			fdt = "fdt-r4pro-8x-emmc";
+			hash-1 { algo = "sha1"; };
+		};
+		conf-r4pro-8x-sd {
+			description = "Boot BPI-R4 Pro 8X (SD)";
+			kernel = "kernel-1";
+			fdt = "fdt-r4pro-8x-sd";
+			hash-1 { algo = "sha1"; };
+		};
 		conf-base {
 			description = "Boot Linux kernel with base FDT blob for BPI-R4 dual SFP+";
 			kernel = "kernel-1";


### PR DESCRIPTION
> `bpi-r4.its` already carries the Pro 8X base node and the storage overlays,
> but no configuration enables the key-M slots cn13/cn14, so NVMe isn't
> available on a stock boot. These two configs point at the pre-merged DTBs so
> a single `#conf-r4pro-8x-emmc` or `#conf-r4pro-8x-sd` boots the 8X with
> both slots up. Additive only; existing configs and the default are unchanged.