### PR TITLE
Don't discard a detected DMA hang without a trace

### DIFF
--- a/drivers/net/ethernet/mediatek/mtk_eth_soc.c
+++ b/drivers/net/ethernet/mediatek/mtk_eth_soc.c
@@ -4622,8 +4622,13 @@ static void mtk_hw_reset_monitor_work(struct work_struct *work)
 		goto out;
 
 	/* DMA stuck checks */
-	if (mtk_hw_check_dma_hang(eth) && atomic_read(&eth->reset.force))
-		schedule_work(&eth->pending_work);
+	if (mtk_hw_check_dma_hang(eth)) {
+		if (atomic_read(&eth->reset.force))
+			schedule_work(&eth->pending_work);
+		else
+			dev_err_ratelimited(eth->dev,
+					    "DMA hang detected, automatic recovery is disabled (echo 2 > /sys/kernel/debug/mtketh/reset to enable)\n");
+	}
 
 out:
 	schedule_delayed_work(&eth->reset.monitor_work,


### PR DESCRIPTION
> `049c428f2eb` gates hang-triggered SER behind `eth->reset.force`, which
> defaults to off. `mtk_hw_reset_monitor_work()` still runs
> `mtk_hw_check_dma_hang()` every second, but with the gate closed a positive
> detection is dropped silently: the engine stays in whatever state tripped
> three consecutive checks, and nothing records it.
>
> Upstream schedules recovery unconditionally here, so the gate is a
> deliberate deviation — keeping it, but emitting a ratelimited error when a
> detection is dropped, so degraded-DMA states can be correlated with traffic
> symptoms from the log alone. No functional change when no hang is detected
> or when forced reset is enabled.