### PR TITLE
arm64: dts: r4pro: add serial0-2 aliases for stable ttyS numbering

### DIFF
--- a/arch/arm64/boot/dts/mediatek/mt7988a-bananapi-bpi-r4-pro.dtsi
+++ b/arch/arm64/boot/dts/mediatek/mt7988a-bananapi-bpi-r4-pro.dtsi
@@ -16,6 +16,9 @@
 / {
 	aliases {
 		ethernet0 = &gmac0;
+		serial0 = &serial0;
+		serial1 = &serial1;
+		serial2 = &serial2;
 		i2c0 = &i2c0;
 		i2c1 = &i2c1;
 		i2c2 = &i2c2;


### PR DESCRIPTION
The full serial0-2 alias set from the [forum thread](https://forum.banana-pi.org/t/bpi-r4-pro-8x-on-7-1-main-boot-stuck-root-cause-lan1-lan6-mac-fixes-patches/27755)

Without serial aliases the ttyS numbers follow probe order. On 7.1 UART1 registers first and takes ttyS0, so console=ttyS0 attaches to a UART with no header pins and the console goes dark when the boot console hands over, even on an otherwise healthy boot. Alias serial0-2 to the three UARTs so the debug header is always ttyS0.

Validated on a BPI-R4 Pro 8x on 7.1-main: with the aliases, ttyS0 is always the debug header regardless of probe order, and a native login console comes up on it.
