### PR TITLE
arm64: dts: bpi-r4-pro-8x: fix stale ds_mux0 reg after port renumbering

### DIFF
--- a/arch/arm64/boot/dts/mediatek/mt7988a-bananapi-bpi-r4-pro-8x.dts
+++ b/arch/arm64/boot/dts/mediatek/mt7988a-bananapi-bpi-r4-pro-8x.dts
@@ -121,7 +121,7 @@
 
 		ds_mux0: ds-mux@0 {
 			compatible = "mxl862xx,ds-mux";
-			reg = <12>;
+			reg = <13>;
 			chan-sel-gpios = <&pio 54 GPIO_ACTIVE_HIGH>;
 			// SFP1 module detect (shared with sfp1 node)
 			mod-def0-gpios = <&pio 69 GPIO_ACTIVE_LOW>;


### PR DESCRIPTION
 The stale ds_mux0 reg from the [forum thread](https://forum.banana-pi.org/t/bpi-r4-pro-8x-on-7-1-main-boot-stuck-root-cause-lan1-lan6-mac-fixes-patches/27755)

 With reg = <12>, ds_add_mux attaches at a port that no longer has a ports{} node, phylink_create sees empty supported_interfaces ("failed to add ds_mux"), and the serdes lane is never routed to the AS21 PHY - port 13 links but forwards nothing in either direction, in any phy-mode.

- Moving the port node back to <12> instead is rejected by the switch firmware (CMD 0202 error -1022, probe fails -EIO) — 13 is the valid port number and the mux side is the stale one.
- With reg = <13> the mux failures are gone and the port forwards.

The block is currently commented out, so this only corrects the description for when it is re-enabled. The same reg = <12> is present on 7.2-rc, so it likely wants the same fix there.