### PR TITLE
net: dsa: mxl862xx: wait for internal GPHYs before registering MDIO bus

### DIFF
--- a/drivers/net/dsa/mxl862xx/mxl862xx.c
+++ b/drivers/net/dsa/mxl862xx/mxl862xx.c
@@ -13,6 +13,7 @@
 #include <linux/icmpv6.h>
 #include <linux/if_bridge.h>
 #include <linux/if_vlan.h>
+#include <linux/mii.h>
 #include <linux/module.h>
 #include <linux/of_device.h>
 #include <linux/of_mdio.h>
@@ -77,6 +78,9 @@ static const struct ethtool_rmon_hist_range mxl862xx_rmon_ranges[] = {
 
 #define MXL862XX_READY_TIMEOUT_MS	10000
 #define MXL862XX_READY_POLL_MS		100
+
+#define MXL862XX_PHY_READY_TIMEOUT_MS	5000
+#define MXL862XX_PHY_READY_POLL_MS	20
 
 #define MXL862XX_TCM_INST_SEL		0xe00
 #define MXL862XX_TCM_CBS		0xe12
@@ -268,6 +272,25 @@ static int mxl862xx_phy_write_mmd(struct mxl862xx_priv *priv, int addr,
 	return MXL862XX_API_WRITE(priv, INT_GPHY_WRITE, param);
 }
 
+/* Quiet variant for polling: relay errors are expected while a GPHY is
+ * still booting its own firmware.
+ */
+static int mxl862xx_phy_read_quiet(struct mxl862xx_priv *priv, int addr,
+				   int regnum)
+{
+	struct mdio_relay_data param = {
+		.phy = addr,
+		.reg = cpu_to_le16(regnum),
+	};
+	int ret;
+
+	ret = MXL862XX_API_READ_QUIET(priv, INT_GPHY_READ, param);
+	if (ret)
+		return ret;
+
+	return le16_to_cpu(param.data);
+}
+
 static int mxl862xx_phy_read_mii_bus(struct mii_bus *bus, int addr, int regnum)
 {
 	return mxl862xx_phy_read_mmd(bus->priv, addr, 0, regnum);
@@ -339,6 +362,7 @@ static int mxl862xx_setup_mdio(struct dsa_switch *ds)
 {
 	struct mxl862xx_priv *priv = ds->priv;
 	struct device *dev = ds->dev;
+	struct device_node *child;
 	struct device_node *mdio_np;
 	struct mii_bus *bus;
 	int ret;
@@ -360,6 +384,45 @@ static int mxl862xx_setup_mdio(struct dsa_switch *ds)
 	mdio_np = of_get_child_by_name(dev->of_node, "mdio");
 	if (!mdio_np)
 		return -ENODEV;
+
+	/* The switch reports ready once its management firmware answers
+	 * commands, but each internal GPHY keeps booting its own
+	 * firmware for a window beyond that and the relay answers even
+	 * ID-register reads with an error until it is done.
+	 * of_mdiobus_register()'s one-shot scan permanently drops any
+	 * address that fails.  Wait for every DT-declared PHY to
+	 * identify itself before registering the bus.  The timeout is
+	 * deliberately generous: the window is firmware-dependent, and
+	 * the GPHYs boot in parallel so normally only the first address
+	 * polled waits at all.
+	 *
+	 * ds->phys_mii_mask cannot locate the PHYs here: it carries
+	 * user port indices (lan1 = port 1) while the GPHYs answer at
+	 * MDIO addresses 0-3.
+	 */
+	for_each_available_child_of_node(mdio_np, child) {
+		unsigned int waited;
+		u32 addr;
+		int id = 0;
+
+		if (of_property_read_u32(child, "reg", &addr) || addr > 31)
+			continue;
+
+		for (waited = 0; waited <= MXL862XX_PHY_READY_TIMEOUT_MS;
+		     waited += MXL862XX_PHY_READY_POLL_MS) {
+			id = mxl862xx_phy_read_quiet(priv, addr, MII_PHYSID1);
+			if (id > 0 && id != 0xffff)
+				break;
+			msleep(MXL862XX_PHY_READY_POLL_MS);
+		}
+		if (id <= 0 || id == 0xffff)
+			dev_warn(dev,
+				 "internal PHY %u not responding; its port will be missing\n",
+				 addr);
+		else if (waited)
+			dev_info(dev, "internal PHY %u ready after %ums\n",
+				 addr, waited);
+	}
 
 	ret = devm_of_mdiobus_register(dev, bus, mdio_np);
 	of_node_put(mdio_np);


### PR DESCRIPTION
Fixes the intermittent lan1-missing-at-boot race from [t/27755](https://forum.banana-pi.org/t/bpi-r4-pro-8x-on-7-1-main-boot-stuck-root-cause-lan1-lan6-mac-fixes-patches/27755): the one-shot mdiobus scan can hit address 0 while that GPHY is still booting its own firmware, and the single failed ID read drops the port until rebind or reboot.

The fix polls every DT-declared PHY for a valid PHYSID1 before `of_mdiobus_register()`, using a quiet relay read (same idiom as `mxl862xx_wait_ready()`) so the wait produces no error spam. On timeout it warns and continues, so a genuinely absent PHY behaves as today, minus the silence.

Validated on two BPI-R4 Pro 8x.

The race is distinct from the CMD-1802 flood fixed by #207 - it reproduced on a tree with those fixes applied. Timing numbers are from this board/firmware; the generous timeout is deliberate since the window is firmware-dependent.