### PR TITLE
net: dsa: mxl862xx: statistics, PCS state and conduit TX queue fixes

### DIFF
--- a/drivers/net/dsa/mxl862xx/mxl862xx-phylink.c
+++ b/drivers/net/dsa/mxl862xx/mxl862xx-phylink.c
@@ -114,6 +114,12 @@ static void mxl862xx_legacy_pcs_get_state(struct phylink_pcs *pcs,
 	};
 	int ret;
 
+	/* phylink presets state->link = 1 before calling pcs_get_state();
+	 * make sure a failed firmware read reports link down instead of a
+	 * spurious link up with SPEED_UNKNOWN.
+	 */
+	state->link = false;
+
 	ret = MXL862XX_API_READ(priv, MXL862XX_COMMON_PORTLINKCFGGET,
 				port_link_cfg);
 	if (ret)
@@ -408,6 +414,12 @@ static void mxl862xx_pcs_get_state(struct phylink_pcs *pcs,
 	struct mxl862xx_xpcs_pcs_state st = {};
 	int if_mode, ret;
 	u16 fw_speed, lpa, bmsr;
+
+	/* phylink presets state->link = 1 before calling pcs_get_state();
+	 * make sure a failed firmware read reports link down instead of a
+	 * spurious link up with SPEED_UNKNOWN.
+	 */
+	state->link = false;
 
 	if_mode = mxl862xx_xpcs_if_mode(state->interface);
 	if (if_mode < 0)

--- a/drivers/net/dsa/mxl862xx/mxl862xx.c
+++ b/drivers/net/dsa/mxl862xx/mxl862xx.c
@@ -4412,8 +4412,6 @@ static void mxl862xx_stats_poll(struct dsa_switch *ds, int port)
 		mxl862xx_delta32(rx_under, s->prev_rx_under_size_error_pkts) +
 		mxl862xx_delta32(rx_over, s->prev_rx_oversize_error_pkts) +
 		mxl862xx_delta32(rx_align, s->prev_rx_align_error_pkts);
-	s->tx_errors +=
-		mxl862xx_delta32(tx_drop, s->prev_tx_dropped_pkts);
 
 	s->rx_dropped +=
 		mxl862xx_delta32(rx_drop, s->prev_rx_dropped_pkts) +

--- a/net/dsa/tag_mxl862xx.c
+++ b/net/dsa/tag_mxl862xx.c
@@ -53,6 +53,9 @@ static struct sk_buff *mxl862_tag_xmit(struct sk_buff *skb,
 	mxl862_tag[2] = htons(FIELD_PREP(MXL862_SUBIF_ID, sub_interface));
 	mxl862_tag[3] = htons(FIELD_PREP(MXL862_IGP_EGP, cpu_port));
 
+	/* Tag the frame for the conduit's per-port TX queue */
+	skb_set_queue_mapping(skb, dp->index);
+
 	return skb;
 }
 

--- a/net/dsa/tag_mxl862xx_8021q.c
+++ b/net/dsa/tag_mxl862xx_8021q.c
@@ -23,6 +23,9 @@ static struct sk_buff *mxl862_8021q_xmit(struct sk_buff *skb,
 	u16 queue_mapping = skb_get_queue_mapping(skb);
 	u8 pcp = netdev_txq_to_tc(netdev, queue_mapping);
 
+	/* Tag the frame for the conduit's per-port TX queue */
+	skb_set_queue_mapping(skb, dp->index);
+
 	return dsa_8021q_xmit(skb, netdev, ETH_P_8021Q,
 			      (pcp << VLAN_PRIO_SHIFT) | tx_vid);
 }


### PR DESCRIPTION
Three independent mxl862xx fixes, unrelated to each other and to the firmware
version. None is required to boot; each removes a real defect. They apply
cleanly on `7.1-main` in either order relative to the `tag_8021q` forwarding
series, so this can be merged before or after it.

### The series

1. **`do not count transmit drops as transmit errors`**
   `get_stats64` folds the GDM transmit-drop counter into `tx_errors`. Drops and
   errors are separate conditions and `rtnl_link_stats64` has a field for each,
   so a congested port currently reports errors that never occurred. One line,
   `ethtool -S` and `ip -s link` only.

2. **`report link down when the PCS state read fails`**
   `phylink_mac_pcs_get_state()` presets `state->link = 1` before invoking
   `pcs_get_state()`. Both the legacy and XPCS implementations return early when
   the firmware mailbox read fails — or, in the XPCS path, when the interface
   mode is unknown — leaving the preset link-up in place with `SPEED_UNKNOWN`
   and no negotiated pause. A transient mailbox timeout is then reported to
   phylink as a valid link. Initialising `state->link` to false on entry makes
   any early exit report link down, which phylink handles by retrying on the
   next poll.

3. **`tag_mxl862xx: assign per-port conduit TX queues`**
   `mtk_eth_soc` gives each DSA user port its own QDMA transmit queue:
   `mtk_select_queue()` maps a switch-bound frame onto
   `skb_get_queue_mapping(skb) + 3`, and `mtk_device_event()` programs that
   queue's rate and WRR weight from the user port's resolved link speed. The
   contract, established by `tag_mtk.c`, is that the tagger stamps the
   originating port index into the skb queue mapping on xmit. Neither MxL862xx
   tagger does, so every frame arrives with mapping 0 and:

   - all switch-bound traffic from every user port serialises onto queue 3,
     regardless of destination port or tagger;
   - queue 3 belongs to port index 0, which is not a user port on any MxL862xx
     board, so its scheduler entry is never programmed after
     `mtk_dma_tx_alloc()` — it runs with a WRR weight of zero and no configured
     rate;
   - the per-port queues `mtk_device_event()` does program (queues 4–7 for
     lan1–lan4 on the MxL86252C) carry no traffic at all.

   Ports 13 and above still fold back to queue 0 in `mtk_select_queue()`
   because their queue index would exceed the 16-entry array. That is unchanged
   behaviour and an `mtk_eth_soc` limitation, not a tagger one.
